### PR TITLE
Case insensitive video finding

### DIFF
--- a/skelly_viewer/gui/qt/widgets/multi_video_display.py
+++ b/skelly_viewer/gui/qt/widgets/multi_video_display.py
@@ -8,6 +8,7 @@ from PySide6.QtCore import QThread, Qt, Signal
 from PySide6.QtGui import QPixmap, QImage
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QGridLayout, QLabel, QApplication
 
+from skelly_viewer.utilities.get_video_paths import get_video_paths
 from skelly_viewer.utilities.video_handler import VideoHandler
 
 logger = logging.getLogger(__name__)
@@ -50,7 +51,7 @@ class MultiVideoDisplay(QWidget):
         self.update_worker = UpdateDisplayWorker([])
 
     def generate_video_display(self, path_to_video_folder: Union[str, Path]):
-        self._video_handler_dictionary = self._create_video_handlers(list(Path(path_to_video_folder).glob('*.mp4')))
+        self._video_handler_dictionary = self._create_video_handlers(get_video_paths(path_to_video_folder))
         self._image_label_widget_dictionary = self._create_image_label_widgets_for_videos(
             number_of_videos=len(self._video_handler_dictionary))
         self._add_widgets_to_layout()

--- a/skelly_viewer/utilities/get_video_paths.py
+++ b/skelly_viewer/utilities/get_video_paths.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import Union
+
+
+def get_video_paths(path_to_video_folder: Union[str, Path]) -> list:
+    """Search the folder for 'mp4' files (case insensitive) and return them as a list"""
+
+    list_of_video_paths = list(Path(path_to_video_folder).glob("*.mp4")) + list(
+        Path(path_to_video_folder).glob("*.MP4")
+    )
+    unique_list_of_video_paths = get_unique_list(list_of_video_paths)
+
+    return unique_list_of_video_paths
+
+
+def get_unique_list(list: list) -> list:
+    """Return a list of the unique elements from input list"""
+    unique_list = []
+    [unique_list.append(element) for element in list if element not in unique_list]
+
+    return unique_list


### PR DESCRIPTION
Glob behavior is inconsistent across operating systems, so as its currently implemented skellyviewer can not find `.MP4`s (capitalized) on unix machines. This PR implements the same case insensitive search we use on the other freemocap subrepos to fix this. 

Fixes #6 