### PR TITLE
Find annotated videos first

### DIFF
--- a/skelly_viewer/utilities/freemocap_data_loader.py
+++ b/skelly_viewer/utilities/freemocap_data_loader.py
@@ -42,12 +42,13 @@ class FreeMoCapDataLoader:
         raise Exception(f"Could not find a skeleton NPY file in path {str(self.find_output_data_folder_path())}")
 
     def find_synchronized_videos_folder_path(self) -> Path:
-        for subfolder_path in self._recording_folder_path.iterdir():
-            if subfolder_path.name == 'annotated_videos':
-                return subfolder_path
-            if subfolder_path.name == 'synchronized_videos':
-                return subfolder_path
-            if subfolder_path.name == 'SyncedVideos':
-                return subfolder_path
+        subpaths = list(self._recording_folder_path.glob('*'))
+
+        if self._recording_folder_path / 'annotated_videos' in subpaths:
+            return self._recording_folder_path / 'annotated_videos'
+        if self._recording_folder_path / 'synchronized_videos' in subpaths:
+            return self._recording_folder_path / 'synchronized_videos'
+        if self._recording_folder_path / 'SyncedVideos' in subpaths:
+            return self._recording_folder_path / 'SyncedVideos'
 
         raise Exception(f"Could not find a videos folder in path {str(self._recording_folder_path)}")


### PR DESCRIPTION
This PR makes it so skelly_viewer shows the annotated videos first if they exist, and the synchronized videos only if the annotated videos don't exist.

The prior solution used Pathlib's `iterdir` function, which returns an [arbitrary order](https://docs.python.org/3/library/pathlib.html#pathlib.Path.iterdir). Because this arbitrary order was iterated through and returned the first match of a videos folder, it was chance whether it returned the annotated videos folder first.

The fix gets all paths in the folder with a `glob` search, and then checks in the desired order if each video path is in the list.