### PR TITLE
update max python version in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = ["pytest",
     "pandas==2.1.*",
     "matplotlib==3.8.2"]
 
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.9,<3.13"
 
 dynamic = ["version"]
 


### PR DESCRIPTION
Add support for python 3.12. See https://github.com/freemocap/freemocap/pull/609