### PR TITLE
Patch Bumpver Action

### DIFF
--- a/.github/workflows/bump_version_on_commit_to_main.yml
+++ b/.github/workflows/bump_version_on_commit_to_main.yml
@@ -31,5 +31,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install bumpver
+    - name: Setup git identification
+      run: |
+        git config user.name 'GitHub Actions'
+        git config user.email 'info@freemocap.org'
     - name: Bump Version
       run: bumpver update --patch


### PR DESCRIPTION
Add name and email to the git config for github actions. This fixes #17  (at least the immediate problem failing), which was complaining that the git merge needed an associated name and email. This signs the name as Github Actions, so it's clear that the action is responsible for the merge.