### PR TITLE
add help argument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,4 @@ push            = true
 
 
 [project.scripts]
-skelly_viewer = "skelly_viewer.__main__:main"
+skelly_viewer = "skelly_viewer.__main__:run"

--- a/skelly_viewer/__main__.py
+++ b/skelly_viewer/__main__.py
@@ -1,7 +1,16 @@
 # __main__.py
 
-from skelly_viewer.gui.qt.skellyview_main_window import main
+import argparse
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="SkellyViewer")
+    return parser.parse_args()
+
+def run():
+    parse_args()
+
+    from skelly_viewer.gui.qt.skellyview_main_window import main
+    main()
 
 if __name__ == "__main__":
-    main()
+    run()


### PR DESCRIPTION
Starter attempt at adding a help argument to skelly_viewer. 

To test:

1) Create a fresh install of skelly_viewer for this PR
2) Try `skelly_viewer --help` 
3) Try 'python -m skelly_viewer --help`

for 2 and 3 you should get a print statement that reads:
```
(skellyviewer_dev) C:\Users\aaron\Documents\GitHub\skelly_viewer>skelly_viewer --help
Thank you for using skelly_viewer!
This is printing from: C:\Users\aaron\Documents\GitHub\skelly_viewer\skelly_viewer\__init__.py
Source code for this package is available at: https://github.com/freemocap/skelly_viewer/
[2024-11-27 12:01:20.0529] [    INFO] [skelly_viewer.config.logging_configuration] [configure_logging():40] [PID:78672 TID:59904] Added logging handlers: [<StreamHandler <stdout> (DEBUG)>, <FileHandler C:\Users\aaron\skelly_viewer_data\logs_info_and_settings\logs\log_2024-11-27T12_01_20ms528_gmt-5.log (DEBUG)>]
usage: skelly_viewer [-h]

SkellyViewer

options:
  -h, --help  show this help message and exit
  ```
  
  NOTE: I changed the entry point in the `pyproject.toml` in order to get `skelly_viewer --help` to work in addition to `python -m skelly_viewer --help` 