### PR TITLE
Give Bumpver action write permissions

### DIFF
--- a/.github/workflows/bump_version_on_commit_to_main.yml
+++ b/.github/workflows/bump_version_on_commit_to_main.yml
@@ -8,13 +8,10 @@
 
 name: Bump Version
 on:
-  push:
-#    branches:
-#      - main
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   deploy:
@@ -22,9 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: true
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
fixes the action permissions (and turn offs auto run, which commenting didn't seem to do)

Also bumps the actions to the latest v4 version