### PR TITLE
Sort video paths

### DIFF
--- a/skelly_viewer/utilities/get_video_paths.py
+++ b/skelly_viewer/utilities/get_video_paths.py
@@ -10,7 +10,7 @@ def get_video_paths(path_to_video_folder: Union[str, Path]) -> list:
     )
     unique_list_of_video_paths = get_unique_list(list_of_video_paths)
 
-    return unique_list_of_video_paths
+    return sorted(unique_list_of_video_paths, key=lambda p: str(p).lower())
 
 
 def get_unique_list(list: list) -> list:


### PR DESCRIPTION
Sort the video path list so behavior is stable across different OS

As part of the effort here: https://github.com/freemocap/freemocap/pull/682 to fix this issue: https://github.com/freemocap/freemocap/issues/681
